### PR TITLE
Include cstddef in batch.h

### DIFF
--- a/src/batch.h
+++ b/src/batch.h
@@ -27,6 +27,7 @@
 #define __OpenCSG__batch_h__
 
 #include "opencsgConfig.h"
+#include <cstddef>
 #include <vector>
 
 namespace OpenCSG {


### PR DESCRIPTION
I got this error with GCC 12:

    batch.h:49:9: error: 'size_t' does not name a type
       49 |         size_t size() const;
          |         ^~~~~~
    batch.h:1:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
      +++ |+#include <cstddef>
        1 | // OpenCSG - library for image-based CSG rendering for OpenGL

This fixes it, as the helpful error message indicates.