### PR TITLE
Fix compile error with size_t usage.

### DIFF
--- a/src/batch.cpp
+++ b/src/batch.cpp
@@ -44,7 +44,7 @@ namespace OpenCSG {
 
         FullscreenPrimitive fullscreen;
 
-        const size_t numberOfPrimitives = primitives.size();
+        const std::size_t numberOfPrimitives = primitives.size();
         mBatches.reserve(numberOfPrimitives);
 
         std::vector<Batch> batchCandidates;
@@ -118,7 +118,7 @@ namespace OpenCSG {
         return mBatches.end();
     }
 
-    size_t Batcher::size() const {
+    std::size_t Batcher::size() const {
         return mBatches.size();
     }
 

--- a/src/batch.h
+++ b/src/batch.h
@@ -28,6 +28,7 @@
 
 #include "opencsgConfig.h"
 #include <vector>
+#include <cstddef>
 
 namespace OpenCSG {
 
@@ -46,7 +47,7 @@ namespace OpenCSG {
         /// returns end of batches
         std::vector<Batch>::const_iterator end() const;
         /// return number of batches
-        size_t size() const;
+        std::size_t size() const;
 
     private:
         std::vector<Batch> mBatches;

--- a/src/renderSCS.cpp
+++ b/src/renderSCS.cpp
@@ -299,7 +299,7 @@ namespace OpenCSG {
 
         void renderIntersectedFront(const std::vector<Primitive*>& primitives) {
 
-            const size_t numberOfPrimitives = primitives.size();
+            const std::size_t numberOfPrimitives = primitives.size();
 
             glDepthMask(GL_TRUE);
 
@@ -446,7 +446,7 @@ namespace OpenCSG {
         bool subtractPrimitivesWithOcclusionQueries(std::vector<Batch>::const_iterator begin,
                                                     std::vector<Batch>::const_iterator end) {
 
-            const size_t numberOfBatches = end - begin;
+            const std::size_t numberOfBatches = end - begin;
             if (numberOfBatches == 0) {
                 return true;
             }


### PR DESCRIPTION
I'm getting this error on Debian/testing, but also happens on the flathub builder (https://github.com/flathub/org.openscad.OpenSCAD/pull/17).
Some of the usage could probably skip the `std::` relying on ADL but as that's still partially a mystery to me, so I changed all the occurences :smiley:.