### PR TITLE
Fix opencsg.h not installed with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(OpenCSG LANGUAGES CXX VERSION 1.7.1)
 option(BUILD_EXAMPLE "Build example program" ON)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
+include(GNUInstallDirs)
+
 add_subdirectory(src)
 if(BUILD_EXAMPLE)
     add_subdirectory(example)


### PR DESCRIPTION
CMake Warning (dev) at src/CMakeLists.txt:39 (install):
  Target opencsg has PUBLIC_HEADER files but no PUBLIC_HEADER DESTINATION.