### PR TITLE
CMakeLists: remove unused target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,8 +35,6 @@ set_target_properties(opencsg PROPERTIES
 
 find_package(OpenGL REQUIRED)
 
-target_link_libraries(opencsg PRIVATE OpenGL::OpenGL)
-
 install(TARGETS opencsg
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
While building the latest version of OpenCSG for Homebrew we were running into a build error;

>  Target "opencsg" links to: OpenGL::OpenGL but the target was not found.

We have been able to build successfully, and run a basic test on MacOS and Linux after removing the line in this PR.

Homebrew ref: https://github.com/Homebrew/homebrew-core/pull/209496