### PR TITLE
Fix CMake install error for MACOSX_BUNDLE target

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(opencsgexample PRIVATE
 )
 
 install(TARGETS opencsgexample
+    BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX}/Applications
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
This PR fixes a CMake configuration error when building on macOS. The `opencsgexample` executable is defined as a MACOSX_BUNDLE, but the install rule previously omitted the required BUNDLE DESTINATION clause, leading to the following error:

```
install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable target "opencsgexample".
```